### PR TITLE
Android automatic refactor - ViewHolder

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlymemory/ui/navigation/StatisticsActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlymemory/ui/navigation/StatisticsActivity.java
@@ -221,17 +221,32 @@ public class StatisticsActivity extends AppCompatActivity {
             orderedNameCountMapping = sortByValue(orderedNameCountMapping);
         }
 
-        @Override
+        private static class ViewHolderItem {
+			private TextView txtTitle;
+			private ImageView imageView;
+		}
+
+		@Override
         public View getView(int position, View view, ViewGroup parent) {
-            // invert index to show resource with highest false selection count on the top
+            ViewHolderItem viewHolderItem;
+			// invert index to show resource with highest false selection count on the top
             int invertedIndex = orderedNameCountMapping.size() - position - 1;
             LayoutInflater inflater = activity.getLayoutInflater();
-            View rowView = inflater.inflate(R.layout.activity_single_statistics_entry, null, true);
-            TextView txtTitle = (TextView) rowView.findViewById(R.id.card_false_selected_stats);
+            if (view == null) {
+				view = inflater.inflate(R.layout.activity_single_statistics_entry, null, true);
+				viewHolderItem = new ViewHolderItem();
+				viewHolderItem.txtTitle = (TextView) view.findViewById(R.id.card_false_selected_stats);
+				viewHolderItem.imageView = (ImageView) view.findViewById(R.id.card_image);
+				convertView.setTag(viewHolderItem);
+			} else {
+				viewHolderItem = (ViewHolderItem) convertView.getTag();
+			}
+			View rowView = view;
+			TextView txtTitle = viewHolderItem.txtTitle;
             txtTitle.setText("\t" + activity.getResources().getString(R.string.false_selected) + "\t" + getCountAtPosition(invertedIndex));
 
             // get drawable from resource name
-            ImageView imageView = (ImageView) rowView.findViewById(R.id.card_image);
+            ImageView imageView = viewHolderItem.imageView;
             int drawableResourceId = activity.getResources().getIdentifier(getResourceNameAtPosition(invertedIndex), "drawable", activity.getPackageName());
             imageView.setImageResource(drawableResourceId);
 


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "ViewHolder".

When developing list views, it is very common to repeat work in every item. Something very common is retrieving a field with the API method ```findViewById```. There is a ViewHolder pattern that lets you reuse the work made in the previous computed item.

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis