### PR TITLE
Android automatic refactor - ObsoleteLayoutParam

### DIFF
--- a/app/src/main/res/layout/fragment_type_main_content.xml
+++ b/app/src/main/res/layout/fragment_type_main_content.xml
@@ -1,32 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+  <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:paddingLeft="@dimen/activity_horizontal_margin"
+  android:paddingRight="@dimen/activity_horizontal_margin"
+  android:paddingTop="@dimen/activity_vertical_margin"
+  android:paddingBottom="@dimen/activity_vertical_margin"
+  android:gravity="center_horizontal|center_vertical"
+  android:orientation="vertical"
+  android:weightSum="8"
+  tools:context="org.secuso.privacyfriendlymemory.ui.MainActivity$GameTypeFragment">
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+  <TextView android:id="@+id/section_label"
+    android:text="Label"
+    android:textStyle="bold"
+    android:textSize="20sp"
+    android:layout_weight="1"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"/>
+
+  <ImageView android:layout_weight="5"
+    android:id="@+id/gameTypeImage"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:gravity="center_horizontal|center_vertical"
-    android:orientation="vertical"
-    android:weightSum="8"
-    tools:context="org.secuso.privacyfriendlymemory.ui.MainActivity$GameTypeFragment">
-
-    <TextView android:id="@+id/section_label"
-        android:text="Label"
-        android:textStyle="bold"
-        android:textSize="20sp"
-        android:layout_weight="1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
-
-    <ImageView
-        android:layout_weight="5"
-        android:id="@+id/gameTypeImage"
-        android:layout_width="match_parent"
-        android:adjustViewBounds="true"
-        android:layout_centerInParent="true"
-        android:src="@drawable/ic_person_black_24px"
-        android:layout_height="0dp" />
-
+    android:adjustViewBounds="true"
+    android:src="@drawable/ic_person_black_24px"
+    android:layout_height="0dp">
+    <!--Removed ObsoleteLayoutParam: layout_centerInParent-->
+  </ImageView>
 </LinearLayout>


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "ObsoleteLayoutParam".

While developing your application's views you might be specifying attributes in a view's artefact that are not necessary due to the nature of its parent. In this PR, those attributes were replaced by a comment.

I have made a previous validation of the changes and they seem correct.
Unfortunately, this tool is not able keep the original whitespace of the files, so comparison without ignoring whitespace might be confusing.
Please consider the changes and let me know if you agree with them.

Best,
Luis