### PR TITLE
Increased SDK target version to 26

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Further development requires Android Studio.
 ### API Reference
 
 Mininum SDK: 17
-Target SDK: 25 
+Target SDK: 26 
 
 ## License
 
@@ -47,7 +47,7 @@ App-Icon: <br />
 Markus Hau<br />
 
 Github-Users: <br />
-Xrygramming <br />
+hanneshofmann <br />
 yonjuni <br />
 Kamuno <br />
 Poussinou

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
 
     defaultConfig {
         applicationId "org.secuso.privacyfriendlymemory"
         minSdkVersion 17
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 3
         versionName "1.0.2"
     }
@@ -21,6 +21,6 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.12'
-    implementation 'com.android.support:appcompat-v7:25.3.1'
-    implementation 'com.android.support:design:25.3.1'
+    implementation 'com.android.support:appcompat-v7:26.0.1'
+    implementation 'com.android.support:design:26.1.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:design:25.3.1'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:25.3.1'
+    implementation 'com.android.support:design:25.3.1'
 }


### PR DESCRIPTION
This MR increases the Android SDK target version to 26 (closes https://github.com/SecUSo/privacy-friendly-memo-game/issues/26). Additionally, the deprecated Gradle `compile` and `testCompile` methods were replaced by appropriate substitutions.

@Kamuno Would you mind to have a look?