### PR TITLE
Displayed score and highscore separately on win screen

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlymemory/ui/MemoActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlymemory/ui/MemoActivity.java
@@ -221,7 +221,7 @@ public class MemoActivity extends MemoAppCompatDrawerActivity {
     private void saveHighscore() {
         if (!memory.isMultiplayer()) {
             MemoGameHighscore highscore = memory.getHighscore();
-            int actualCore = highscore.getScore();
+            int actualScore = highscore.getScore();
             int actualTries = highscore.getTries();
             int actualTime = highscore.getTime();
             MemoGameDifficulty difficulty = memory.getDifficulty();
@@ -246,8 +246,8 @@ public class MemoActivity extends MemoAppCompatDrawerActivity {
                     break;
             }
             int currentScore = preferences.getInt(highscoreConstants, 0);
-            if (actualCore > currentScore) {
-                preferences.edit().putInt(highscoreConstants, actualCore).commit();
+            if (actualScore > currentScore) {
+                preferences.edit().putInt(highscoreConstants, actualScore).commit();
                 preferences.edit().putInt(highscoreTriesConstants, actualTries).commit();
                 preferences.edit().putInt(highscoreTimeConstants, actualTime).commit();
             }
@@ -358,11 +358,24 @@ public class MemoActivity extends MemoAppCompatDrawerActivity {
             ((TextView) findViewById(R.id.win_tries)).setText(String.valueOf(highscore.getTries()));
             // highscore is not valid if a custom deck is selected
             if (highscore.isValid()) {
-                ((TextView) findViewById(R.id.win_highscore)).setText(String.valueOf(highscore.getScore()));
+                ((TextView) findViewById(R.id.win_score)).setText(String.valueOf(highscore.getScore()));
+                ((TextView) findViewById(R.id.win_highscore)).setText(String.valueOf(getSavedHighscore()));
             } else {
                 ((TextView) findViewById(R.id.win_highscore_text)).setText("");
             }
 
+        }
+
+        private int getSavedHighscore() {
+            switch(memory.getDifficulty()) {
+                case Easy:
+                    return preferences.getInt(Constants.HIGHSCORE_EASY, 0);
+                case Moderate:
+                    return preferences.getInt(Constants.HIGHSCORE_MODERATE, 0);
+                case Hard:
+                    return preferences.getInt(Constants.HIGHSCORE_HARD, 0);
+            }
+            return 0;
         }
     }
 
@@ -415,8 +428,6 @@ public class MemoActivity extends MemoAppCompatDrawerActivity {
             }
             return winnerName;
         }
-
-
     }
 
 }

--- a/app/src/main/res/layout/win_solo_screen_layout.xml
+++ b/app/src/main/res/layout/win_solo_screen_layout.xml
@@ -40,79 +40,103 @@
             android:layout_width="0dp"
             android:layout_height="fill_parent"
             android:layout_weight="3"
-            android:gravity="center"
             android:background="@color/transparent"
+            android:gravity="center"
             android:orientation="vertical"
-            android:weightSum="5"
-            >
+            android:weightSum="5">
+
             <LinearLayout
-                android:layout_width="120dp"
-                android:layout_height="0dp"
-                android:layout_weight="4"
-                android:layout_marginTop="46dp"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
                 android:layout_gravity="center_horizontal"
-                android:orientation="vertical"
                 android:layout_marginLeft="5dp"
-                android:layout_marginRight="5dp">
+                android:layout_marginTop="27dp"
+                android:layout_marginRight="5dp"
+                android:orientation="vertical">
+
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/win_text"
-                    android:textAlignment="center"
                     android:layout_gravity="center_horizontal"
-                    android:textColor="@color/white"/>
+                    android:text="@string/win_text"
+                    android:textSize="11dp"
+                    android:textAlignment="center"
+                    android:textColor="@color/black" />
+
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/win_time"
                     android:layout_gravity="center"
-                    android:textColor="@color/white"/>
+                    android:text="@string/win_time"
+                    android:textColor="@color/white" />
+
                 <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
                     android:id="@+id/win_time"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
                     android:text=""
-                    android:textColor="@color/white"
-                    android:layout_gravity="center_horizontal"/>
+                    android:textColor="@color/white" />
+
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_gravity="center"
                     android:text="@string/win_tries"
-                    android:textColor="@color/white"
-                    android:layout_gravity="center" />
+                    android:textColor="@color/white" />
+
                 <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
                     android:id="@+id/win_tries"
-                    android:text=""
-                    android:textColor="@color/white"
-                    android:layout_gravity="center_horizontal"/>
-                <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/win_highscore"
-                    android:textColor="@color/white"
+                    android:layout_gravity="center_horizontal"
+                    android:text=""
+                    android:textColor="@color/white" />
+
+                <TextView
+                    android:id="@+id/win_score_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="@string/win_score"
+                    android:textColor="@color/white" />
+
+                <TextView
+                    android:id="@+id/win_score"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:text=""
+                    android:textColor="@color/white" />
+
+                <TextView
                     android:id="@+id/win_highscore_text"
-                    android:layout_gravity="center" />
-                <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="@string/win_highscore"
+                    android:textColor="@color/white" />
+
+                <TextView
                     android:id="@+id/win_highscore"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
                     android:text=""
-                    android:textColor="@color/white"
-                    android:layout_gravity="center_horizontal"/>
+                    android:textColor="@color/white" />
             </LinearLayout>
 
             <LinearLayout
                 android:layout_width="fill_parent"
                 android:layout_height="0dp"
                 android:layout_weight="1">
+
                 <View
                     android:layout_width="fill_parent"
                     android:layout_height="20dp"
-                    android:background="@color/middleblue"
                     android:layout_gravity="bottom"
-                    android:foregroundGravity="bottom"/>
+                    android:background="@color/middleblue"
+                    android:foregroundGravity="bottom" />
             </LinearLayout>
         </LinearLayout>
         <LinearLayout

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -83,6 +83,7 @@
     <string name="win_text_duo_draw">Unentschieden!</string>
     <string name="win_time">Zeit:</string>
     <string name="win_tries">Versuche:</string>
+    <string name="win_score">Score:</string>
     <string name="win_highscore">Highscore:</string>
     <string name="win_button_text">Fortsetzen</string>
     <string name="win_show_game">Zeige Spielfeld</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -78,6 +78,7 @@
     <string name="win_text_duo_draw">Match nul !</string>
     <string name="win_time">Temps :</string>
     <string name="win_tries">Essais :</string>
+    <string name="win_score">Score :</string>
     <string name="win_highscore">Meilleur score :</string>
     <string name="win_button_text">Continuer</string>
     <string name="win_show_game">Afficher le jeu</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -79,6 +79,7 @@
     <string name="win_text_duo_draw">引き分け!</string>
     <string name="win_time">時間:</string>
     <string name="win_tries">回数:</string>
+    <string name="win_score">スコア:</string>
     <string name="win_highscore">ハイスコア:</string>
     <string name="win_button_text">続行</string>
     <string name="win_show_game">ゲームフィールドを表示</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,7 @@
     <string name="win_text_duo_draw">Draw!</string>
     <string name="win_time">Time:</string>
     <string name="win_tries">Tries:</string>
+    <string name="win_score">Score:</string>
     <string name="win_highscore">Highscore:</string>
     <string name="win_button_text">Continue</string>
     <string name="win_show_game">Show gamefield</string>


### PR DESCRIPTION
This MR separates the score and the highscore so that both values are shown on the win screen:

![Score-and-Highscore-UI](https://user-images.githubusercontent.com/8657035/55742307-ac2b6a80-5a2f-11e9-9f69-d337a202e61d.png)


Closes https://github.com/SecUSo/privacy-friendly-memo-game/issues/21 and https://github.com/SecUSo/privacy-friendly-memo-game/issues/23.