### PR TITLE
Fixed potential memory leak in the statistics activity

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlymemory/ui/navigation/StatisticsActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlymemory/ui/navigation/StatisticsActivity.java
@@ -68,6 +68,12 @@ public class StatisticsActivity extends AppCompatActivity {
         tabLayout.setupWithViewPager(mViewPager);
     }
 
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        statisticsActivity = null;
+    }
+
     private void setupActionBar() {
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 30 16:20:16 CET 2020
+#Thu Mar 05 17:25:34 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
This PR fixes a potential memory leak as described in #31. The static variable gets de-referenced on the `onDestory` hook before the activity gets eventually persisted. 

Closes: #31 